### PR TITLE
Frequency deviation/receiver bandwidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ With the default Frequency Deviation of 5 kHz and Receiver Bandwidth of 10.4 kHz
 is very unreliable and fails completely for me, when the temperature of the transmitter is below 
 ~10°C and above 40°C, while the receiver temperature is at 20°C. The receiver does not seem to be 
 prone to temperature changes.  
-Increasing Frequency Deviation to 40 kHz and Receiver Bandwidth to 80.3 kHz, temperature susceptibility 
+Increasing Frequency Deviation to 10 kHz and Receiver Bandwidth to 20.8 kHz, temperature susceptibility 
 is eliminated; when testing with transmitter temperature from -20°C to 50°C, packet transmission is 
 perfectly reliable.
 
-Frequency Deviation = 40 kHz (transmitter)  
-`RegFdevMsb` = `0x02`  
-`RegFdevLsb` = `0x90`  
+Frequency Deviation = 10 kHz (transmitter)  
+`RegFdevMsb` = `0x00`  
+`RegFdevLsb` = `0xa4`  
 
-Receiver Bandwidth = 80.3 kHz  
-`RegRxBw` = `0x52`  
+Receiver Bandwidth = 20.8 kHz  
+`RegRxBw` = `0x54`  
 
 ## Fun Stuff
 

--- a/avrrfm.c
+++ b/avrrfm.c
@@ -162,18 +162,16 @@ static void displayTemp(uint8_t rssi, bool crc, uint16_t raw) {
     uint8_t _rssi = divRoundNearest(rssi, 2);
     int16_t tempx10 = convertTSens(raw);
     div_t temp = div(tempx10, 10);
-    
-    static char buf[42];
 
-    snprintf(buf, sizeof (buf), "RSSI: %d dBm, CRC: %d, %d.%d°C\r\n", 
-            -_rssi, crc, temp.quot, abs(temp.rem));
-    printString(buf);
-    
+    char buf[32];
+
     snprintf(buf, sizeof (buf), "RSSI: %4d dBm, CRC: %d", -_rssi, crc);
     const __flash Font *unifont = &unifontFont;
     writeString(0, 0, unifont, buf, WHITE, BLACK);
 
-    snprintf(buf, sizeof (buf), "%4d.%d°", temp.quot, abs(temp.rem));
+    snprintf(buf, sizeof (buf), "%c%d.%d°", tempx10 < 0 ? '-' : ' ',
+            abs(temp.quot), abs(temp.rem));
+
     const __flash Font *dejaVu = &dejaVuFont;
     if (width > 0) fillArea(xo, yo, width, dejaVu->height, WHITE);
     if (yl == 0) yl = unifont->height;
@@ -222,7 +220,7 @@ int main(void) {
         initDisplay();
 
         setFrame(0xffff);
-    
+
         // initial rx mode
         startReceive();
     }

--- a/rfm69.c
+++ b/rfm69.c
@@ -94,11 +94,11 @@ void initRadio(uint32_t freq) {
     // regWrite(BITRATE_MSB, 0x0d);
     // regWrite(BITRATE_LSB, 0x05);
 
-    // frequency deviation (default 5 kHz) - increasing to 40 kHz 
+    // frequency deviation (default 5 kHz) - increasing to 10 kHz 
     // completely removes susceptibility to temperature changes
     // RX_BW must be increased accordingly
-    regWrite(FDEV_MSB, 0x02);
-    regWrite(FDEV_LSB, 0x90);
+    regWrite(FDEV_MSB, 0x00);
+    regWrite(FDEV_LSB, 0xa4);
 
     // RC calibration, automatically done at device power-up
     // regWrite(OSC1, 0x80);
@@ -120,12 +120,12 @@ void initRadio(uint32_t freq) {
     // regWrite(TEST_LNA, 0x2d);
 
     // freq of DC offset canceller and channel filter bandwith (default 10.4 kHz)
-    // increasing to 80.3 kHz in connection with setting FDEV_*SB  to 40 kHz 
+    // increasing to 20.8 kHz in connection with setting FDEV_*SB to 10 kHz 
     // completely removes susceptibility to temperature changes
-    regWrite(RX_BW, 0x52);
+    regWrite(RX_BW, 0x54);
 
-    // RX_BW during AFC (default)
-    regWrite(AFC_BW, 0x88);
+    // RX_BW during AFC (default 0x8b)
+    regWrite(AFC_BW, 0x8a);
     
     // AFC auto on
     // regWrite(AFC_FEI, 0x04);


### PR DESCRIPTION
- 10/20 kHz is enough to remove temperature susceptibility
- fix display of negative temperature values