### PR TITLE
Refactor imeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ very good and in an actual "field" test, packet reception was still reliable
 with an RSSI of about -90 dBm at about 2.2 km distance - with simple wire 
 antennas. What would be the range with +20 dBm and decent antennas?  
 
-![IMG_20250306_180139c](https://github.com/user-attachments/assets/27c66e7a-ec16-4e98-9f94-7713fe54c7d0)
+![IMG_20250315_175920c](https://github.com/user-attachments/assets/03405774-57c2-42f1-a39a-8fa4cc2801ac)
 
 ![FieldTest3](https://github.com/user-attachments/assets/f2289f8e-1f81-4b85-9146-07c2ce1bb563)
 

--- a/rfm69.h
+++ b/rfm69.h
@@ -80,6 +80,8 @@
 #define F_STEP          6103515625ULL
 #define CAST_ADDRESS    0x84
 
+#define TIMEOUT_INTS    3 // about 100 milliseconds 
+
 /**
  * Initializes the radio module with the given carrier frequency in kilohertz
  * and node address.
@@ -99,6 +101,13 @@ void setOutputPower(uint8_t rssi);
  * @return ouput power
  */
 uint8_t getOutputPower(void);
+
+/**
+ * Enables or disables the radio timeout.
+ * 
+ * @param enable
+ */
+void timeoutEnable(bool enable);
 
 /**
  * Indicates a timeout.


### PR DESCRIPTION
- move related code to radio
- cancel timeout when "PayloadReady" arrives
- reduce timeout from 1 second to 100 milliseconds
- no delay before transmitting feedback to transmitter